### PR TITLE
Correct Updates page to align with Docs History page

### DIFF
--- a/source/changes-4.5.html
+++ b/source/changes-4.5.html
@@ -17,7 +17,7 @@ title: 'Rainmeter 4.5 Changes'
 
 		<p class="revision"><b>August 27, 2024 - 4.5.20 - Revision 3803</b></p>
 		<ul>
-			<li><span class="badge badge-fixed">Fixed</span><b>Rainmeter Build:</b> Change Rainmeter updater URL to use HTTPS, to prevent possible "Man in the Middle" attack.</li>
+			<li><span class="badge badge-fixed">Fixed</span><b>Rainmeter Build:</b> Change Rainmeter updater URL to use HTTPS, to prevent possible "Machine in the Middle" attack.</li>
 			<li><span class="badge badge-fixed">Fixed</span><b>Ping Plugin:</b> Fixed timing issue with FinishAction.</li>
 			<li><span class="badge badge-fixed">Fixed</span><b>Command Handler:</b> Fixed issue with the !ToggleConfig bang.</li>
 			<li><span class="badge badge-fixed">Fixed</span><b>AudioLevel Plugin:</b> Fix first FFT band.</li>


### PR DESCRIPTION
Simple commit to be consistent, the updates page mentions both **"Man in the Middle"** and **"Machine in the Middle"** attacks a few lines apart.
Made it so "Machine in the Middle" is used in both instances, which is what the [docs also dose](https://github.com/rainmeter/rainmeter-docs/commit/d8bcae81566c8135017ece24fe75c6224b4c9556).